### PR TITLE
Add polling to dataset and document management pages

### DIFF
--- a/web/components/dataset/dataset-table.tsx
+++ b/web/components/dataset/dataset-table.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/services/dataset-service";
 import DatasetDrawer from "./dataset-drawer";
 import {useRouter} from "next/router";
+import usePolling from "@/hooks/polling";
 
 const DatasetTable: React.FC = () => {
   const [datasets, setDatasets] = useState<Dataset[]>([]);
@@ -33,6 +34,8 @@ const DatasetTable: React.FC = () => {
     const result = await getDatasets();
     setDatasets(result);
   };
+
+  usePolling(fetchDatasets, 5000);
 
   const handleDocumentManagement = (dataset: Dataset) => {
     router.push(`/dataset/${dataset.name}/documents`);

--- a/web/components/scene/scene-table.tsx
+++ b/web/components/scene/scene-table.tsx
@@ -18,6 +18,7 @@ import {
 import SceneDrawer from "./scene-drawer";
 import Dataset from "@/models/dataset";
 import {getDatasets} from "@/services/dataset-service";
+import usePolling from "@/hooks/polling";
 
 const SceneTable: React.FC = () => {
   const [scenes, setScenes] = useState<Scene[]>([]);
@@ -39,6 +40,9 @@ const SceneTable: React.FC = () => {
     const result = await getDatasets();
     setDatasets(result);
   }
+
+  usePolling(fetchScenes, 5000);
+  usePolling(fetchDatasets, 5000);
 
   const handleDelete = async (id: number) => {
     try {

--- a/web/hooks/polling.ts
+++ b/web/hooks/polling.ts
@@ -1,0 +1,26 @@
+import { useEffect, useRef } from 'react';
+
+type FetchDataFunction = () => Promise<void>;
+
+const usePolling = (fetchData: FetchDataFunction, interval: number) => {
+  const pollingInterval = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const startPolling = () => {
+      const intervalId = setInterval(() => {
+        fetchData();
+      }, interval);
+      pollingInterval.current = intervalId;
+    };
+
+    startPolling();
+
+    return () => {
+      if (pollingInterval.current) {
+        clearInterval(pollingInterval.current);
+      }
+    };
+  }, [fetchData, interval]);
+};
+
+export default usePolling;

--- a/web/pages/dataset/[name]/documents/index.tsx
+++ b/web/pages/dataset/[name]/documents/index.tsx
@@ -4,6 +4,7 @@ import React, {useEffect, useState} from 'react';
 import {useRouter} from 'next/router';
 import Document from '@/models/document';
 import {getDocuments, uploadDocument, deleteDocument, reprocessDocument} from '@/services/document-service';
+import usePolling from "@/hooks/polling";
 
 const {Column} = Table;
 
@@ -22,6 +23,8 @@ const DocumentPage = () => {
     const docs = await getDocuments(datasetName as string);
     setDocuments(docs);
   };
+
+  usePolling(fetchDocuments, 5000);
 
   const handleUpload = async (info: any) => {
     if (info.file.status === 'done') {


### PR DESCRIPTION
This PR adds a polling feature to the dataset and document management pages to keep the displayed information up-to-date. This allows users to see the latest status without manually refreshing the page.

Changes include:
- Implement `usePolling` custom hook for handling polling logic
- Add polling functionality to dataset list, scene list, and document list pages